### PR TITLE
Add UnionPay and Maestro support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+2.0.0
+=====
+
+- Add support for Maestro and UnionPay
+- Change return type of `length` as a `String` to `lengths` as an `Array`
+
+1.0.0
+=====
+
+- Initial Release

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ console.log(card.type); // 'visa'
 
 `getCardType` will return an Object with the following data:
 
-| Key | Value | Description |
-| --- | ----- | ----------- |
-| `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `MasterCard`<br />- `American Express`<br />- `DinersClub`<br />- `Discover`<br />- `JCB` |
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `MasterCard`<br />- `American Express`<br />- `DinersClub`<br />- `Discover`<br />- `JCB`<br />- `UnionPay`<br />- `Maestro` |
 | `type` | `String` | A code-friendly presentation of the card brand (useful to class names in CSS).<br/>- `visa`<br />- `master-card`<br />- `american-express`<br />- `diners-club`<br />- `discover`<br />- `jcb` |
 | `pattern` | `RegExp` | The regular expression used to determine the card type. |
 | `gaps` | `Array` | The expected indeces of gaps in a string representation of the card number. For example, in a Visa card, `4111 1111 1111 1111`, there are expected spaces in the 4th, 8th, and 12th positions. This is useful in setting your own formatting rules. |
-| `length` | `Integer` | The expected length of the card number string (excluding spaces and `/` characters). |
+| `lengths` | `Array` | The expected lengths of the card number as an array of strings (excluding spaces and `/` characters). |
 | `code` | `Object` | The information regarding the security code for the determined card. Learn more about the [code object](#code) below. |
 
 #### `code`
@@ -42,6 +42,8 @@ Card brands provide different nomenclature for their security codes as well as v
 | `DinersClub` | `CVV` | 3 |
 | `Discover` | `CID` | 3 |
 | `JCB` | `CVV` | 3 |
+| `UnionPay` | `CVN` | 3 |
+| `Maestro` | `CVC` | 3 |
 
 A full response for a `Visa` card will look like this:
 
@@ -51,7 +53,7 @@ A full response for a `Visa` card will look like this:
   type: 'visa',
   pattern: '^4[0-9][\\s\\d]*$',
   gaps: [ 4, 8, 12 ],
-  length: 16,
+  lengths: [16],
   code: { name: 'CVV', size: 3 }
 }
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "credit-card-type",
   "main": "index.js",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/braintree/credit-card-type",
   "authors": [
     "braintree <code@getbraintree.com>"

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var types = [
   {
     niceType: 'Visa',
     type: 'visa',
-    pattern: '^4[0-9][\\s\\d]*$',
+    pattern: '^4\\d*$',
     gaps: [4, 8, 12],
-    length: 16,
+    lengths: [16],
     code: {
       name: 'CVV',
       size: 3
@@ -16,9 +16,9 @@ var types = [
   {
     niceType: 'MasterCard',
     type: 'master-card',
-    pattern: '^5[1-5][\\s\\d]*$',
+    pattern: '^5[1-5]\\d*$',
     gaps: [4, 8, 12],
-    length: 16,
+    lengths: [16],
     code: {
       name: 'CVC',
       size: 3
@@ -27,10 +27,10 @@ var types = [
   {
     niceType: 'American Express',
     type: 'american-express',
-    pattern: '^3[47][\\s\\d]*$',
+    pattern: '^3[47]\\d*$',
     isAmex: true,
     gaps: [4, 10],
-    length: 15,
+    lengths: [15],
     code: {
       name: 'CID',
       size: 4
@@ -39,9 +39,9 @@ var types = [
   {
     niceType: 'DinersClub',
     type: 'diners-club',
-    pattern: '^3(?:0[0-5]|[68][0-9])[\\s\\d]*$',
+    pattern: '^3(0[0-5]|[689])\\d*$',
     gaps: [4, 10],
-    length: 14,
+    lengths: [14],
     code: {
       name: 'CVV',
       size: 3
@@ -50,9 +50,9 @@ var types = [
   {
     niceType: 'Discover',
     type: 'discover',
-    pattern: '^6(?:011|5[0-9]{2})[\\s\\d]*$',
+    pattern: '^6(011|5|4[4-9])\\d*$',
     gaps: [4, 8, 12],
-    length: 16,
+    lengths: [16],
     code: {
       name: 'CID',
       size: 3
@@ -61,14 +61,37 @@ var types = [
   {
     niceType: 'JCB',
     type: 'jcb',
-    pattern: '^(?:2131|1800|35)[\\s\\d]*$',
+    pattern: '^(2131|1800|35)\\d*$',
     gaps: [4, 8, 12],
-    length: 16,
+    lengths: [16],
     code: {
       name: 'CVV',
       size: 3
     }
-  }];
+  },
+  {
+    niceType: 'UnionPay',
+    type: 'unionpay',
+    pattern: '^62\\d*$',
+    gaps: [4, 8, 12],
+    lengths: [16, 17, 18, 19],
+    code: {
+      name: 'CVN',
+      size: 3
+    }
+  },
+  {
+    niceType: 'Maestro',
+    type: 'maestro',
+    pattern: '^(50|5[6-9]|6)\\d*$',
+    gaps: [4, 8, 12],
+    lengths: [12, 13, 14, 15, 16, 17, 18, 19],
+    code: {
+      name: 'CVC',
+      size: 3
+    }
+  }
+];
 
 module.exports = function getCardType(cardNumber) {
   var key, value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "credit-card-type",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A library for determining credit card type",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,11 @@ describe('getCardType', function () {
       ['6011111111111117', 'discover'],
       ['6011000990139424', 'discover'],
 
+      ['6221558812340000', 'unionpay'],
+      ['6269992058134322', 'unionpay'],
+
+      ['6304000000000000', 'maestro'],
+
       ['3530111333300000', 'jcb'],
       ['3566002020360505', 'jcb']
     ];
@@ -75,8 +80,34 @@ describe('getCardType', function () {
       expect(getCardType('30569309025904').code.name).to.equal('CVV');
     });
     it('DinersClub', function () {
-      expect(getCardType('3530111333300000').code.size).to.equal(3);
-      expect(getCardType('3530111333300000').code.name).to.equal('CVV');
+      expect(getCardType('30569309025904').code.size).to.equal(3);
+      expect(getCardType('30569309025904').code.name).to.equal('CVV');
+    });
+    it('UnionPay', function () {
+      expect(getCardType('6221558812340000').code.size).to.equal(3);
+      expect(getCardType('6221558812340000').code.name).to.equal('CVN');
+    });
+    it('Maestro', function () {
+      expect(getCardType('6304000000000000').code.size).to.equal(3);
+      expect(getCardType('6304000000000000').code.name).to.equal('CVC');
+    });
+  });
+
+  describe('returns lengths for', function () {
+    it('maestro', function () {
+      expect(getCardType('63').lengths).to.deep.equal([12,13,14,15,16,17,18,19]);
+    });
+    it('diners club', function () {
+      expect(getCardType('305').lengths).to.deep.equal([14]);
+    });
+    it('discover', function () {
+      expect(getCardType('6011').lengths).to.deep.equal([16]);
+    });
+    it('visa', function () {
+      expect(getCardType('4').lengths).to.deep.equal([16]);
+    });
+    it('mastercard', function () {
+      expect(getCardType('54').lengths).to.deep.equal([16]);
     });
   });
 


### PR DESCRIPTION
This is a Major (2.0.0) change as it required the returned `length` attribute to become an array of possibly valid `lengths`.