### PR TITLE
Remove lodash, accepts numbers, consistent return.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,7 +73,6 @@
     no-loop-func: 2
     no-multi-spaces: 2
     no-multi-str: 2
-    no-native-reassign: 2
     no-new: 2
     no-new-func: 2
     no-new-wrappers: 2

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-var isString = require('lodash/lang/isString');
-var clone = require('lodash/lang/cloneDeep');
-
 var types = [
   {
     niceType: 'Visa',
@@ -97,15 +94,11 @@ module.exports = function getCardTypes(cardNumber) {
   var i, value;
   var result = [];
 
-  if (!isString(cardNumber)) { return result; }
-
-  if (cardNumber === '') { return clone(types); }
-
   for (i = 0; i < types.length; i++) {
     value = types[i];
 
-    if (RegExp(value.pattern).test(cardNumber)) {
-      result.push(clone(value));
+    if (new RegExp(value.pattern).test(cardNumber)) {
+      result.push(value);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ var types = [
     niceType: 'American Express',
     type: 'american-express',
     pattern: '^3([47]\\d*)?$',
-    isAmex: true,
     gaps: [4, 10],
     lengths: [15],
     code: {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "vinyl-source-stream": "^1.0.0"
-  },
-  "dependencies": {
-    "lodash": "3.10.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,14 @@ var expect = require('chai').expect;
 var getCardType = require('../index');
 
 describe('getCardType', function () {
-  it('returns an empty array if passed non-strings', function () {
+  it('returns an empty array if no matches', function () {
     expect(getCardType()).to.deep.equal([]);
+    expect(getCardType(undefined)).to.deep.equal([]);
+    expect(getCardType('')).to.deep.equal([]);
     expect(getCardType(null)).to.deep.equal([]);
     expect(getCardType(true)).to.deep.equal([]);
     expect(getCardType(false)).to.deep.equal([]);
     expect(getCardType('ren hoek')).to.deep.equal([]);
-    expect(getCardType(3920342)).to.deep.equal([]);
     expect(getCardType([])).to.deep.equal([]);
     expect(getCardType({})).to.deep.equal([]);
   });
@@ -105,7 +106,6 @@ describe('getCardType', function () {
 
   describe('ambiguous card types', function () {
     var ambiguous = [
-      ['', ['visa', 'master-card', 'american-express', 'diners-club', 'discover', 'jcb', 'unionpay', 'maestro']],
       ['3', ['american-express', 'diners-club', 'jcb']],
       ['5', ['master-card', 'maestro']],
       ['6', ['discover', 'maestro', 'unionpay']]
@@ -242,9 +242,21 @@ describe('getCardType', function () {
     expect(getCardType(number)[0].type).to.equal('visa');
   });
 
+  it('works for Number objects', function () {
+    var number = new Number('4111111111111111');
+    expect(getCardType(number)[0].type).to.equal('visa');
+  });
+
   it('preserves integrity of returned values', function () {
     var result = getCardType('4111111111111111');
     result.type = 'whaaaaaat';
+    expect(result.type).to.equal('whaaaaaat');
     expect(getCardType('4111111111111111')[0].type).to.equal('visa');
+  });
+
+  it('numbers work as expected', function () {
+    var test = getCardType(4111);
+    expect(test.length).to.equal(1);
+    expect(test[0].type).to.equal('visa');
   });
 });


### PR DESCRIPTION
This PR removes lodash. There isn't any mutation of the type object so it does not need to be cloned. 
There is no need to clone() an object that is being pushed onto an array.

The other thing lodash did was force string input. Instead, this returns a match as expected. Maintains consistent returns/inputs.

For the same idea of consistent inputs/returns, I removed an empty string ```''``` from returning the ```types``` object. It should return what any un-matched input should.

Removed ```isAmex``` from types as it was not consistent with the rest of the results and unnecessary with the ```.type``` field.

Fixed running eslint error.