### PR TITLE
Discover Union Pay cards.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,7 +62,6 @@
     no-empty-label: 2
     no-eq-null: 0
     no-eval: 2
-    no-native-reassign: 2
     no-extra-bind: 2
     no-fallthrough: 2
     no-floating-decimal: 2

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var isString = require('lodash/lang/isString');
 var clone = require('lodash/lang/cloneDeep');
-var range = require('lodash/utility/range');
 
 var types = [
   {
@@ -53,7 +52,7 @@ var types = [
     type: 'discover',
     pattern: discoverPattern(),
     gaps: [4, 8, 12],
-    lengths: [16],
+    lengths: [16, 19],
     code: {
       name: 'CID',
       size: 3
@@ -114,10 +113,15 @@ module.exports = function getCardTypes(cardNumber) {
 };
 
 function unionPayAndDiscoverPattern() {
-  var firstPatternBins = range(622126, 622925 + 1);
-  var firstPattern = '^(' + firstPatternBins.join('|') + ')\\d{10,13}$';
-  var secondPattern = '^(62[4-6])\\d{13,16}$';
-  var thirdPattern = '^(628[2-9])\\d{12,15}$';
+  var i, firstPattern, secondPattern, thirdPattern;
+  var firstPatternBins = [];
+
+  for (i = 622126; i <= 622925; i++) { firstPatternBins.push(i); }
+
+  firstPattern = '^(' + firstPatternBins.join('|') + ')\\d*$';
+  secondPattern = '^(62[4-6])\\d*$';
+  thirdPattern = '^(628[2-9])\\d*$';
+
   return [firstPattern, secondPattern, thirdPattern].join('|');
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var isString = require('lodash/lang/isString');
 var clone = require('lodash/lang/cloneDeep');
+var range = require('lodash/utility/range');
 
 var types = [
   {
@@ -50,7 +51,7 @@ var types = [
   {
     niceType: 'Discover',
     type: 'discover',
-    pattern: '^6(0|01|011\\d*|5\\d*|4|4[4-9]\\d*)?$',
+    pattern: discoverPattern(),
     gaps: [4, 8, 12],
     lengths: [16],
     code: {
@@ -111,3 +112,19 @@ module.exports = function getCardTypes(cardNumber) {
 
   return result;
 };
+
+function unionPayAndDiscoverPattern() {
+  var firstPatternBins = range(622126, 622925 + 1);
+  var firstPattern = '^(' + firstPatternBins.join('|') + ')\\d{10,13}$';
+  var secondPattern = '^(62[4-6])\\d{13,16}$';
+  var thirdPattern = '^(628[2-9])\\d{12,15}$';
+  return [firstPattern, secondPattern, thirdPattern].join('|');
+}
+
+function nonUnionPayAndDiscoverPattern() {
+  return '(^6(0|01|011\\d*|5\\d*|4|4[4-9]\\d*)?$)';
+}
+
+function discoverPattern() {
+  return [unionPayAndDiscoverPattern(), nonUnionPayAndDiscoverPattern()].join('|');
+}

--- a/test/index.js
+++ b/test/index.js
@@ -67,8 +67,7 @@ describe('getCardType', function () {
 
       ['62', 'unionpay'],
       ['627', 'unionpay'],
-      ['6221558812340000', 'unionpay'],
-      ['6269992058134322', 'unionpay'],
+      ['6221258812340000', 'unionpay'],
 
       ['50', 'maestro'],
       ['56', 'maestro'],
@@ -91,6 +90,22 @@ describe('getCardType', function () {
       ['3566002020360505', 'jcb']
     ];
 
+    var dualBrandTests = [
+      ['6221260000000000', ['discover', 'unionpay']],
+      ['6221260000000000000', ['discover', 'unionpay']],
+      ['6222000000000000', ['discover', 'unionpay']],
+      ['6228000000000000', ['discover', 'unionpay']],
+      ['6229250000000000', ['discover', 'unionpay']],
+      ['6229250000000000000', ['discover', 'unionpay']],
+      ['6240000000000000', ['discover', 'unionpay']],
+      ['6260000000000000000', ['discover', 'unionpay']],
+      ['6282000000000000', ['discover', 'unionpay']],
+      ['6289000000000000000', ['discover', 'unionpay']],
+      ['6221558812340000', ['discover', 'unionpay']],
+      ['6269992058134322', ['discover', 'unionpay']]
+    ]
+
+
     tests.forEach(function (test) {
       var number = test[0];
       var type = test[1];
@@ -99,6 +114,18 @@ describe('getCardType', function () {
         var actual = getCardType(number);
         expect(actual).to.have.lengthOf(1);
         expect(actual[0].type).to.equal(type);
+      });
+    });
+
+    dualBrandTests.forEach(function (test) {
+      var number = test[0];
+      var types = test[1];
+
+      it('returns type ' + types.join(', ') + ' for ' + number, function () {
+        var actual = getCardType(number);
+        expect(actual).to.have.lengthOf(2);
+        expect(actual[0].type).to.equal(types[0]);
+        expect(actual[1].type).to.equal(types[1]);
       });
     });
   });
@@ -208,7 +235,7 @@ describe('getCardType', function () {
       expect(code.name).to.equal('CVV');
     });
     it('UnionPay', function () {
-      var code = getCardType('6221558812340000')[0].code;
+      var code = getCardType('6220558812340000')[0].code;
       expect(code.size).to.equal(3);
       expect(code.name).to.equal('CVN');
     });

--- a/test/index.js
+++ b/test/index.js
@@ -254,7 +254,7 @@ describe('getCardType', function () {
       expect(getCardType('305')[0].lengths).to.deep.equal([14]);
     });
     it('Discover', function () {
-      expect(getCardType('6011')[0].lengths).to.deep.equal([16]);
+      expect(getCardType('6011')[0].lengths).to.deep.equal([16, 19]);
     });
     it('Visa', function () {
       expect(getCardType('4')[0].lengths).to.deep.equal([16]);


### PR DESCRIPTION
Discover Union Pay cards are now considered as Discover cards in
addition to being considered as Union Pay cards.
Discover shows up first in the list, so any code that picks the first
element in the getCardTypes() result will consider these cards as Discover
cards.