### PR TITLE
Removes lodash dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+- Removes dependency on Lodash
+
 4.0.1
 =====
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var isString = require('lodash/lang/isString');
-var clone = require('lodash/lang/cloneDeep');
-
 var types = [
   {
     niceType: 'Visa',
@@ -99,7 +96,9 @@ module.exports = function getCardTypes(cardNumber) {
   var i, value;
   var result = [];
 
-  if (!isString(cardNumber)) { return result; }
+  if (!(typeof cardNumber === 'string' || cardNumber instanceof String)) {
+    return result;
+  }
 
   if (cardNumber === '') { return clone(types); }
 
@@ -133,4 +132,8 @@ function nonUnionPayAndDiscoverPattern() {
 
 function discoverPattern() {
   return [unionPayAndDiscoverPattern(), nonUnionPayAndDiscoverPattern()].join('|');
+}
+
+function clone(x) {
+  return JSON.parse(JSON.stringify(x));
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "vinyl-source-stream": "^1.0.0"
-  },
-  "dependencies": {
-    "lodash": "3.10.1"
   }
 }


### PR DESCRIPTION
We've been considering this for a while. We are only using lodash for `isString` and `clone`, which for our purposes can be substituted for simple vanilla JS checks.

Addresses #18 and part of #12