### PR TITLE
Added getCard(cardType) and export card type constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Credit Card Type provides a useful utility method for determining a credit card 
 This library is designed for type-as-you-go detection (supports partial numbers) and is written in CommonJS so you can use it in Node, io.js, and the [browser](http://browserify.org).
 
 ## Download
-To install via npm: 
+To install via npm:
 
 ```
 npm install credit-card-type
@@ -21,12 +21,12 @@ bower install credit-card-type
 ## Example
 
 ```javascript
-var getCardTypes = require('credit-card-type');
+var matchCards = require('credit-card-type');
 
-var visaCards = getCardTypes('4111');
+var visaCards = matchCards('4111');
 console.log(visaCards[0].type);  // 'visa'
 
-var ambiguousCards = getCardTypes('6');
+var ambiguousCards = matchCards('6');
 console.log(ambiguousCards.length);       // 3
 console.log(ambiguousCards[0].niceType);  // 'Discover'
 console.log(ambiguousCards[1].niceType);  // 'UnionPay'
@@ -35,20 +35,37 @@ console.log(ambiguousCards[2].niceType);  // 'Maestro'
 
 ## API
 
-### `getCardTypes(number: String)`
+### `matchCards(number: String)`
 
-`getCardTypes` will return an array of objects, each with the following data:
+`matchCards` will return an array of objects, each with the following data:
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
 | `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `MasterCard`<br />- `American Express`<br />- `Diners Club`<br />- `Discover`<br />- `JCB`<br />- `UnionPay`<br />- `Maestro` |
-| `type` | `String` | A code-friendly presentation of the card brand (useful to class names in CSS).<br/>- `visa`<br />- `master-card`<br />- `american-express`<br />- `diners-club`<br />- `discover`<br />- `jcb`<br />- `unionpay`<br />- `maestro` |
+| `type` | `String` | A code-friendly presentation of the card brand (useful to class names in CSS). Please refer to Card Type "Constants" below for the list of possible values.
 | `pattern` | `RegExp` | The regular expression used to determine the card type. |
 | `gaps` | `Array` | The expected indeces of gaps in a string representation of the card number. For example, in a Visa card, `4111 1111 1111 1111`, there are expected spaces in the 4th, 8th, and 12th positions. This is useful in setting your own formatting rules. |
 | `lengths` | `Array` | The expected lengths of the card number as an array of strings (excluding spaces and `/` characters). |
 | `code` | `Object` | The information regarding the security code for the determined card. Learn more about the [code object](#code) below. |
 
 If no card types are found, this returns an empty array.
+
+### `getCard(type: string)`
+
+`getCard` will return a singular object (with the same structure as `matchCards`) corresponding with the specified `type`, or undefined if the specified `type` is invalid/unknown.
+
+### Card Type "Constants"
+
+Named variables are provided for each of the supported card types:
+
+* `VISA`
+* `MASTERCARD`
+* `AMERICAN_EXPRESS`
+* `DINERS_CLUB`
+* `DISCOVER`
+* `JCB`
+* `UNIONPAY`
+* `MAESTRO`
 
 #### `code`
 
@@ -76,6 +93,55 @@ A full response for a `Visa` card will look like this:
   lengths: [16],
   code: { name: 'CVV', size: 3 }
 }
+```
+
+### Advanced Usage
+
+CommonJS:
+
+```
+var matchCards = require('credit-card-type');
+var getCard = require('credit-card-type').getCard;
+var CardType = require('credit-card-type').types;
+```
+
+ES6:
+
+```
+import matchCards, { getCard, types as CardType } from 'credit-card-type')
+```
+
+#### Filtering
+
+```
+matchCards(cardNumber).filter(function(card) {
+  return card.type == CardType.MASTERCARD || card.type == CardType.VISA;
+})
+```
+
+#### Pretty Card Numbers
+
+```
+function prettyCardNumber(cardNumber, cardType) {
+  var card = getCard(cardType);
+
+  if (card) {
+    var offsets = [0].concat(card.gaps).concat([cardNumber.length]);
+    var components = [];
+
+    for (var i = 0; offsets[i] < cardNumber.length; i++) {
+      var start = offsets[i];
+      var end = Math.min(offsets[i + 1], cardNumber.length);
+      components.push(cardNumber.substring(start, end));
+    }
+
+    return components.join(' ');
+  }
+
+  return cardNumber;
+}
+
+prettyCardNumber('xxxxxxxxxx343', CardType.AMERICAN_EXPRESS); // 'xxxx xxxxxx 343'
 ```
 
 ### Development

--- a/index.js
+++ b/index.js
@@ -1,118 +1,151 @@
 'use strict';
 
-var types = [
-  {
-    niceType: 'Visa',
-    type: 'visa',
-    pattern: '^4\\d*$',
-    gaps: [4, 8, 12],
-    lengths: [16],
-    code: {
-      name: 'CVV',
-      size: 3
-    }
-  },
-  {
-    niceType: 'MasterCard',
-    type: 'master-card',
-    pattern: '^(5|5[1-5]\\d*|2|22|222|222[1-9]\\d*|2[3-6]\\d*|27[0-1]\\d*|2720\\d*)$',
-    gaps: [4, 8, 12],
-    lengths: [16],
-    code: {
-      name: 'CVC',
-      size: 3
-    }
-  },
-  {
-    niceType: 'American Express',
-    type: 'american-express',
-    pattern: '^3([47]\\d*)?$',
-    isAmex: true,
-    gaps: [4, 10],
-    lengths: [15],
-    code: {
-      name: 'CID',
-      size: 4
-    }
-  },
-  {
-    niceType: 'Diners Club',
-    type: 'diners-club',
-    pattern: '^3((0([0-5]\\d*)?)|[689]\\d*)?$',
-    gaps: [4, 10],
-    lengths: [14],
-    code: {
-      name: 'CVV',
-      size: 3
-    }
-  },
-  {
-    niceType: 'Discover',
-    type: 'discover',
-    pattern: '^6(0|01|011\\d*|5\\d*|4|4[4-9]\\d*)?$',
-    gaps: [4, 8, 12],
-    lengths: [16, 19],
-    code: {
-      name: 'CID',
-      size: 3
-    }
-  },
-  {
-    niceType: 'JCB',
-    type: 'jcb',
-    pattern: '^((2|21|213|2131\\d*)|(1|18|180|1800\\d*)|(3|35\\d*))$',
-    gaps: [4, 8, 12],
-    lengths: [16],
-    code: {
-      name: 'CVV',
-      size: 3
-    }
-  },
-  {
-    niceType: 'UnionPay',
-    type: 'unionpay',
-    pattern: '^6(2\\d*)?$',
-    gaps: [4, 8, 12],
-    lengths: [16, 17, 18, 19],
-    code: {
-      name: 'CVN',
-      size: 3
-    }
-  },
-  {
-    niceType: 'Maestro',
-    type: 'maestro',
-    pattern: '^((5((0|[6-9])\\d*)?)|(6|6[37]\\d*))$',
-    gaps: [4, 8, 12],
-    lengths: [12, 13, 14, 15, 16, 17, 18, 19],
-    code: {
-      name: 'CVC',
-      size: 3
+var cardTypes = {};
+var cards = {};
+
+cardTypes.VISA = 'visa';
+cards[cardTypes.VISA] = {
+  niceType: 'Visa',
+  type: cardTypes.VISA,
+  pattern: '^4\\d*$',
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'CVV',
+    size: 3
+  }
+};
+
+cardTypes.MASTERCARD = 'master-card';
+cards[cardTypes.MASTERCARD] = {
+  niceType: 'MasterCard',
+  type: cardTypes.MASTERCARD,
+  pattern: '^(5|5[1-5]\\d*|2|22|222|222[1-9]\\d*|2[3-6]\\d*|27[0-1]\\d*|2720\\d*)$',
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'CVC',
+    size: 3
+  }
+};
+
+cardTypes.AMERICAN_EXPRESS = 'american-express';
+cards[cardTypes.AMERICAN_EXPRESS] = {
+  niceType: 'American Express',
+  type: cardTypes.AMERICAN_EXPRESS,
+  pattern: '^3([47]\\d*)?$',
+  isAmex: true,
+  gaps: [4, 10],
+  lengths: [15],
+  code: {
+    name: 'CID',
+    size: 4
+  }
+};
+
+cardTypes.DINERS_CLUB = 'diners-club';
+cards[cardTypes.DINERS_CLUB] = {
+  niceType: 'Diners Club',
+  type: cardTypes.DINERS_CLUB,
+  pattern: '^3((0([0-5]\\d*)?)|[689]\\d*)?$',
+  gaps: [4, 10],
+  lengths: [14],
+  code: {
+    name: 'CVV',
+    size: 3
+  }
+};
+
+cardTypes.DISCOVER = 'discover';
+cards[cardTypes.DISCOVER] = {
+  niceType: 'Discover',
+  type: cardTypes.DISCOVER,
+  pattern: '^6(0|01|011\\d*|5\\d*|4|4[4-9]\\d*)?$',
+  gaps: [4, 8, 12],
+  lengths: [16, 19],
+  code: {
+    name: 'CID',
+    size: 3
+  }
+};
+
+cardTypes.JCB = 'jcb';
+cards[cardTypes.JCB] = {
+  niceType: 'JCB',
+  type: cardTypes.JCB,
+  pattern: '^((2|21|213|2131\\d*)|(1|18|180|1800\\d*)|(3|35\\d*))$',
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'CVV',
+    size: 3
+  }
+};
+
+cardTypes.UNIONPAY = 'unionpay';
+cards[cardTypes.UNIONPAY] = {
+  niceType: 'UnionPay',
+  type: cardTypes.UNIONPAY,
+  pattern: '^6(2\\d*)?$',
+  gaps: [4, 8, 12],
+  lengths: [16, 17, 18, 19],
+  code: {
+    name: 'CVN',
+    size: 3
+  }
+};
+
+cardTypes.MAESTRO = 'maestro';
+cards[cardTypes.MAESTRO] = {
+  niceType: 'Maestro',
+  type: cardTypes.MAESTRO,
+  pattern: '^((5((0|[6-9])\\d*)?)|(6|6[37]\\d*))$',
+  gaps: [4, 8, 12],
+  lengths: [12, 13, 14, 15, 16, 17, 18, 19],
+  code: {
+    name: 'CVC',
+    size: 3
+  }
+};
+
+function forCards(callback) {
+  var key;
+
+  for (key in cards) {
+    if (cards.hasOwnProperty(key)) {
+      callback(cards[key]);
     }
   }
-];
+}
 
-module.exports = function getCardTypes(cardNumber) {
-  var i, value;
+function clone(x) {
+  return x ? JSON.parse(JSON.stringify(x)) : x;
+}
+
+module.exports = function matchCards(cardNumber) {
   var result = [];
 
   if (!(typeof cardNumber === 'string' || cardNumber instanceof String)) {
     return result;
   }
 
-  if (cardNumber === '') { return clone(types); }
-
-  for (i = 0; i < types.length; i++) {
-    value = types[i];
-
-    if (RegExp(value.pattern).test(cardNumber)) {
+  if (cardNumber === '') {
+    forCards(function (value) {
       result.push(clone(value));
-    }
+    });
+  } else {
+    forCards(function (value) {
+      if (RegExp(value.pattern).test(cardNumber)) {
+        result.push(clone(value));
+      }
+    });
   }
 
   return result;
 };
 
-function clone(x) {
-  return JSON.parse(JSON.stringify(x));
-}
+module.exports.getCard = function (cardType) {
+  return clone(cards[cardType]);
+};
+
+module.exports.types = clone(cardTypes);


### PR DESCRIPTION
Firstly, I apologise for large size of the pull request (relative to the size of the project).

Nonetheless, I've added what I suppose most will think is some really useful functionality.

In particular a new exported function:

```
getCard(cardType)
```

This allows users to query data about known (typically persisted) card types, for which the card number itself may no longer available.

This is common in the sense that 99.9% of applications shouldn't actually be storing credit card numbers; that should be left to CC processing experts (BrainTree :wink: etc.) However, storing the last 3-4 digits of a credit card numbers, along with the credit card type, is pretty standard practice as a way to help card owners distinguish between their cards when they have several on file.

Combing this persisted information in conjunction with new `getCard` function allows one to put together UIs like:

<img width="356" alt="card" src="https://cloud.githubusercontent.com/assets/482276/16362634/8a119f86-3bf7-11e6-80d3-263dcaf6b45b.png">

<img width="350" alt="card2" src="https://cloud.githubusercontent.com/assets/482276/16362861/e1c05768-3bfc-11e6-9694-ec170715657c.png">

For convenience, I've also exported card type constants. This means less string literals floating around in the code of consumers of this module.

# Changes

I've renamed `getCardTypes` to `matchCards` in the documentation (well, and in code).

Originally I attempted to avoid this, but following the existing naming scheme led to my function being called `getCardType(type)` - which was very awkward fetching a  "card type" by providing card type! 

Realistically `getCardTypes` was never returning a "card type" as such, instead it returns one or more objects with info matching the specified card number - included in that info is the card `type`, but also some other great information.

Although I've renamed this function, due to this function being the "default export", __the change is actually 100% backward compatible__. So users of the module can upgrade and continue using `getCardTypes` within their own code (if that's the name they had previously chosen to use).

I've updated the README to document the new function and the exposed constants. I've also added a new section called "Advanced Usage" which highlights some use cases for the new functionality.