### PR TITLE
Remove unneeded version key from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "credit-card-type",
   "main": "index.js",
-  "version": "4.0.0",
   "homepage": "https://github.com/braintree/credit-card-type",
   "authors": [
     "braintree <code@getbraintree.com>"


### PR DESCRIPTION
The `version` key is ignored by Bower and is deprecated.

See [the documentation](https://github.com/bower/spec/blob/master/json.md#version).