### PR TITLE
Fix mastercard prefix pattern for numbers starting with 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Fix prefix pattern for MasterCard numbers starting with `27`
+
 5.0.2
 =====
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ types[VISA] = {
 types[MASTERCARD] = {
   niceType: 'MasterCard',
   type: MASTERCARD,
-  prefixPattern: /^(5|5[1-5]|2|22|222|222[1-9]|2[3-6]|27[0-1]|2720)$/,
+  prefixPattern: /^(5|5[1-5]|2|22|222|222[1-9]|2[3-6]|27|27[0-2]|2720)$/,
   exactPattern: /^(5[1-5]|222[1-9]|2[3-6]|27[0-1]|2720)\d*$/,
   gaps: [4, 8, 12],
   lengths: [16],

--- a/test/index.js
+++ b/test/index.js
@@ -39,8 +39,10 @@ describe('creditCardType', function () {
       ['24', 'master-card'],
       ['25', 'master-card'],
       ['26', 'master-card'],
+      ['27', 'master-card'],
       ['270', 'master-card'],
       ['271', 'master-card'],
+      ['272', 'master-card'],
       ['2720', 'master-card'],
 
       ['51', 'master-card'],


### PR DESCRIPTION
Reported here: https://github.com/braintree/card-validator/issues/49

> In my scenario I was entering in a MC in the bin range 222100–272099 and once I entered in `27`, `isPotentiallyValid` returns `false`. If I continue to type in `7` it is still `false` but once I type `0` is is now potentially valid again. 

The problem was that we didn't have 27 and 27[0-2] listed as potentially valid in the prefix pattern.