### PR TITLE
Add new VISA length ranges (e.g. V Pay)

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ types[VISA] = {
   prefixPattern: /^4$/,
   exactPattern: /^4\d*$/,
   gaps: [4, 8, 12],
-  lengths: [16, 18, 19],
+  lengths: [13, 14, 15, 16, 17, 18, 19],
   code: {
     name: CVV,
     size: 3

--- a/test/index.js
+++ b/test/index.js
@@ -262,7 +262,7 @@ describe('creditCardType', function () {
       expect(creditCardType('6011')[0].lengths).to.deep.equal([16, 19]);
     });
     it('Visa', function () {
-      expect(creditCardType('4')[0].lengths).to.deep.equal([16, 18, 19]);
+      expect(creditCardType('4')[0].lengths).to.deep.equal([13, 14, 15, 16, 17, 18, 19]);
     });
     it('MasterCard', function () {
       expect(creditCardType('54')[0].lengths).to.deep.equal([16]);


### PR DESCRIPTION
Fixes #43 

~~Those 13 digits VISAs are no longer used. Or are they? Whatever, we all need to follow specs. And the specs say they exist. Sometimes you can argue with your PO, sometimes you can't. When it comes to payment related stuff chances are that you can't.~~

~~This PR adds support for 13 digits VISAs.~~

This PR adds support for VISA 13 - 19 length change, which is used by VISA debit cards ([source](https://baymard.com/checkout-usability/credit-card-patterns), [what is V Pay](https://en.wikipedia.org/wiki/V_Pay)).