### PR TITLE
Add new Diners Club length ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ types[DINERS_CLUB] = {
   prefixPattern: /^(3|3[0689]|30[0-5])$/,
   exactPattern: /^3(0[0-5]|[689])\d*$/,
   gaps: [4, 10],
-  lengths: [14],
+  lengths: [14, 15, 16, 17, 18, 19],
   code: {
     name: CVV,
     size: 3

--- a/test/index.js
+++ b/test/index.js
@@ -256,7 +256,7 @@ describe('creditCardType', function () {
       expect(creditCardType('6304000000000000')[0].lengths).to.deep.equal([12, 13, 14, 15, 16, 17, 18, 19]);
     });
     it('Diners Club', function () {
-      expect(creditCardType('305')[0].lengths).to.deep.equal([14]);
+      expect(creditCardType('305')[0].lengths).to.deep.equal([14, 15, 16, 17, 18, 19]);
     });
     it('Discover', function () {
       expect(creditCardType('6011')[0].lengths).to.deep.equal([16, 19]);


### PR DESCRIPTION
According to [this doc](https://www.discovernetwork.com/downloads/IPP_VAR_Compliance.pdf) Diners Clip International PANs do now have a much broader length range.

As far as I understand the regexs to still work as expected and don't require an update.