### PR TITLE
Update Docs and Tweak Maestro exactPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ console.log(ambiguousCards[2].niceType);  // 'Maestro'
 |------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `MasterCard`<br />- `American Express`<br />- `Diners Club`<br />- `Discover`<br />- `JCB`<br />- `UnionPay`<br />- `Maestro`                                                                                                           |
 | `type`     | `String` | A code-friendly presentation of the card brand (useful to class names in CSS). Please refer to Card Type "Constants" below for the list of possible values.<br/>- `visa`<br />- `master-card`<br />- `american-express`<br />- `diners-club`<br />- `discover`<br />- `jcb`<br />- `unionpay`<br />- `maestro` |
-| `pattern`  | `RegExp` | The regular expression used to determine the card type.                                                                                                                                                                                                                                                        |
 | `gaps`     | `Array`  | The expected indeces of gaps in a string representation of the card number. For example, in a Visa card, `4111 1111 1111 1111`, there are expected spaces in the 4th, 8th, and 12th positions. This is useful in setting your own formatting rules.                                                            |
 | `lengths`  | `Array`  | The expected lengths of the card number as an array of strings (excluding spaces and `/` characters).                                                                                                                                                                                                          |
 | `code`     | `Object` | The information regarding the security code for the determined card. Learn more about the [code object](#code) below.                                                                                                                                                                                          |
@@ -88,12 +87,13 @@ A full response for a `Visa` card will look like this:
 {
   niceType: 'Visa',
   type: 'visa',
-  pattern: '^4[0-9][\\s\\d]*$',
   gaps: [ 4, 8, 12 ],
   lengths: [16],
   code: { name: 'CVV', size: 3 }
 }
 ```
+
+*Note:* The response also includes an `exactPattern` regex and a `prefixPattern` regex. These are used internally to determine the card type, but they should not be relied on and may be removed in the next major version.
 
 ### Advanced Usage
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,17 @@ function clone(x) {
 
   if (!x) { return null; }
 
+  // TODO: in the next major version, we should
+  // consider removing these pattern properties.
+  // They are not useful extnerally and can be
+  // confusing because the exactPattern does not
+  // always match (for instance, Maestro cards
+  // can start with 62, but the exact pattern
+  // does not include that since it would
+  // exclude UnionPay and Discover cards
+  // when it is not sure whether or not
+  // the card is a UnionPay, Discover or
+  // Maestro card).
   prefixPattern = x.prefixPattern.source;
   exactPattern = x.exactPattern.source;
   dupe = JSON.parse(JSON.stringify(x));

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ types[MAESTRO] = {
   niceType: 'Maestro',
   type: MAESTRO,
   prefixPattern: /^(5|5[06-9]|6\d*)$/,
-  exactPattern: /^5[06-9]\d*$/,
+  exactPattern: /^(5[06-9]|6[37])\d*$/,
   gaps: [4, 8, 12],
   lengths: [12, 13, 14, 15, 16, 17, 18, 19],
   code: {


### PR DESCRIPTION
Remove references to `pattern` in the docs (as they have been replaced with `prefixPattern` and `exactPattern` and add a note about how those patterns shouldn't be relied upon.

Update maestro's exact pattern to match `6[37]`.

Adds a comment to remove pattern properties from the result object in a major version bump, as they are not useful to the end user.