### PR TITLE
update discover exactPattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ types[DISCOVER] = {
   niceType: 'Discover',
   type: DISCOVER,
   prefixPattern: /^(6|60|601|6011|65|64|64[4-9])$/,
-  exactPattern: /^(6011|65|64[4-9])\d*$/,
+  exactPattern: /^(6011|65|6221|6229|64[4-9])\d*$/,
   gaps: [4, 8, 12],
   lengths: [16, 19],
   code: {

--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ types[DINERS_CLUB] = {
 types[DISCOVER] = {
   niceType: 'Discover',
   type: DISCOVER,
-  prefixPattern: /^(6|60|601|6011|65|64|64[4-9])$/,
-  exactPattern: /^(6011|65|6221|6229|64[4-9])\d*$/,
+  prefixPattern: /^(6|60|601|6011|65|64|64[4-9]|622[126-925])$/,
+  exactPattern: /^(6011|65|6221|6229|64[4-9]|622[126-925])\d*$/,
   gaps: [4, 8, 12],
   lengths: [16, 19],
   code: {


### PR DESCRIPTION
Based on the source below* there are a few card numbers that are not evaluated as a Discover card, such as the ones beginning with 6221 or 6229.

* https://www.getnewidentity.com/discover-credit-card.php
