### PR TITLE
Added new lengths for JCB

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ types[JCB] = {
   prefixPattern: /^(2|21|213|2131|1|18|180|1800|3|35)$/,
   exactPattern: /^(2131|1800|35)\d*$/,
   gaps: [4, 8, 12],
-  lengths: [16],
+  lengths: [16, 17, 18, 19],
   code: {
     name: CVV,
     size: 3

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,9 @@ describe('creditCardType', function () {
       ['18002', 'jcb'],
       ['3530111333300000', 'jcb'],
       ['3566002020360505', 'jcb'],
+      ['35308796121637357', 'jcb'],
+      ['353445444300732639', 'jcb'],
+      ['3537286818376838569', 'jcb'],
 
       ['6221260000000000', 'unionpay'],
       ['6221260000000000000', 'unionpay'],
@@ -266,6 +269,9 @@ describe('creditCardType', function () {
     });
     it('MasterCard', function () {
       expect(creditCardType('54')[0].lengths).to.deep.equal([16]);
+    });
+    it('JCB', function () {
+      expect(creditCardType('35')[0].lengths).to.deep.equal([16, 17, 18, 19]);
     });
   });
 


### PR DESCRIPTION
JCB cards were marked as having a length of 16 digits, but they can also be 15 and and 19 digits long. This is not well documented, so it might be a new thing. JCB is a strange credit card.

15 and 16: http://www.regular-expressions.info/creditcard.html
15 and 16: http://developer.ean.com/general-info/valid-card-types/
16-19: https://en.wikipedia.org/wiki/Payment_card_number#Issuer_identification_number_.28IIN.29
16 and 19: https://www.freeformatter.com/credit-card-number-generator-validator.html
