### PR TITLE
Fix Mastercard niceType

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ console.log(ambiguousCards[2].niceType);  // 'Maestro'
 
 | Key        | Type     | Description                                                                                                                                                                                                                                                                                                    |
 |------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `MasterCard`<br />- `American Express`<br />- `Diners Club`<br />- `Discover`<br />- `JCB`<br />- `UnionPay`<br />- `Maestro`                                                                                                           |
+| `niceType` | `String` | A pretty printed representation of the card brand.<br/>- `Visa`<br />- `Mastercard`<br />- `American Express`<br />- `Diners Club`<br />- `Discover`<br />- `JCB`<br />- `UnionPay`<br />- `Maestro`                                                                                                           |
 | `type`     | `String` | A code-friendly presentation of the card brand (useful to class names in CSS). Please refer to Card Type "Constants" below for the list of possible values.<br/>- `visa`<br />- `master-card`<br />- `american-express`<br />- `diners-club`<br />- `discover`<br />- `jcb`<br />- `unionpay`<br />- `maestro` |
 | `gaps`     | `Array`  | The expected indeces of gaps in a string representation of the card number. For example, in a Visa card, `4111 1111 1111 1111`, there are expected spaces in the 4th, 8th, and 12th positions. This is useful in setting your own formatting rules.                                                            |
 | `lengths`  | `Array`  | The expected lengths of the card number as an array of strings (excluding spaces and `/` characters).                                                                                                                                                                                                          |
@@ -73,7 +73,7 @@ Card brands provide different nomenclature for their security codes as well as v
 | Brand              | Name  | Size |
 |--------------------|-------|------|
 | `Visa`             | `CVV` | 3    |
-| `MasterCard`       | `CVC` | 3    |
+| `Mastercard`       | `CVC` | 3    |
 | `American Express` | `CID` | 4    |
 | `Diners Club`      | `CVV` | 3    |
 | `Discover`         | `CID` | 3    |

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ types[VISA] = {
 };
 
 types[MASTERCARD] = {
-  niceType: 'MasterCard',
+  niceType: 'Mastercard',
   type: MASTERCARD,
   prefixPattern: /^(5|5[1-5]|2|22|222|222[1-9]|2[3-6]|27|27[0-2]|2720)$/,
   exactPattern: /^(5[1-5]|222[1-9]|2[3-6]|27[0-1]|2720)\d*$/,

--- a/test/index.js
+++ b/test/index.js
@@ -194,7 +194,7 @@ describe('creditCardType', function () {
   });
 
   describe('returns security codes for', function () {
-    it('MasterCard', function () {
+    it('Mastercard', function () {
       var code = creditCardType('5454545454545454')[0].code;
 
       expect(code.size).to.equal(3);
@@ -264,7 +264,7 @@ describe('creditCardType', function () {
     it('Visa', function () {
       expect(creditCardType('4')[0].lengths).to.deep.equal([16, 18, 19]);
     });
-    it('MasterCard', function () {
+    it('Mastercard', function () {
       expect(creditCardType('54')[0].lengths).to.deep.equal([16]);
     });
   });


### PR DESCRIPTION
Mastercard should be written with a lowercase "c" as seen in their brand guidelines under the section "Using the Mastercard® name in text". https://brand.mastercard.com/brandcenter/mastercard-brand-mark.html

![mastercardname_160826](https://user-images.githubusercontent.com/2223418/31715749-4f56637c-b405-11e7-9b76-b0a0c961c7ba.png)
