### PR TITLE
Remove pattern properties from returned card objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ unreleased
 
 - Update mastercard niceType property to `Mastercard` to match new brand guidelines
 
+__Breaking Changes__
+- Remove internal properties `prefixPattern` and `exactPattern` from returned object
+
 5.0.4
 =====
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ A full response for a `Visa` card will look like this:
 }
 ```
 
-*Note:* The response also includes an `exactPattern` regex and a `prefixPattern` regex. These are used internally to determine the card type, but they should not be relied on and may be removed in the next major version.
-
 ### Advanced Usage
 
 CommonJS:

--- a/index.js
+++ b/index.js
@@ -24,27 +24,14 @@ var testOrder = [
   MAESTRO
 ];
 
-function clone(x) {
-  var prefixPattern, exactPattern, dupe;
+function clone(originalObject) {
+  var dupe;
 
-  if (!x) { return null; }
+  if (!originalObject) { return null; }
 
-  // TODO: in the next major version, we should
-  // consider removing these pattern properties.
-  // They are not useful extnerally and can be
-  // confusing because the exactPattern does not
-  // always match (for instance, Maestro cards
-  // can start with 62, but the exact pattern
-  // does not include that since it would
-  // exclude UnionPay and Discover cards
-  // when it is not sure whether or not
-  // the card is a UnionPay, Discover or
-  // Maestro card).
-  prefixPattern = x.prefixPattern.source;
-  exactPattern = x.exactPattern.source;
-  dupe = JSON.parse(JSON.stringify(x));
-  dupe.prefixPattern = prefixPattern;
-  dupe.exactPattern = exactPattern;
+  dupe = JSON.parse(JSON.stringify(originalObject));
+  delete dupe.prefixPattern;
+  delete dupe.exactPattern;
 
   return dupe;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -289,8 +289,13 @@ describe('getTypeInfo', function () {
 
     expect(info.type).to.equal('visa');
     expect(info.niceType).to.equal('Visa');
-    expect(info.prefixPattern).to.be.a('string');
-    expect(info.exactPattern).to.be.a('string');
+  });
+
+  it('removes pattern attributes', function () {
+    var info = creditCardType.getTypeInfo(creditCardType.types.VISA);
+
+    expect(info.exactPattern).to.equal(undefined); // eslint-disable-line no-undefined
+    expect(info.prefixPattern).to.equal(undefined); // eslint-disable-line no-undefined
   });
 
   it('returns null for an unknown type', function () {


### PR DESCRIPTION
We're going to do a major version bump and remove the pattern properties from the card objects. This PR removes those properties.