### PR TITLE
Correct Mastercard bin range for series 2 bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Correct Mastercard bin range for series 2 bins
+
 6.1.0
 =====
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ types[MASTERCARD] = {
   niceType: 'Mastercard',
   type: MASTERCARD,
   prefixPattern: /^(5|5[1-5]|2|22|222|222[1-9]|2[3-6]|27|27[0-2]|2720)$/,
-  exactPattern: /^(5[1-5]|222[1-9]|2[3-6]|27[0-1]|2720)\d*$/,
+  exactPattern: /^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\d*$/,
   gaps: [4, 8, 12],
   lengths: [16],
   code: {

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,8 @@ describe('creditCardType', function () {
       ['2226', 'master-card'],
       ['2225', 'master-card'],
       ['2226', 'master-card'],
+      ['223', 'master-card'],
+      ['2239', 'master-card'],
       ['23', 'master-card'],
       ['24', 'master-card'],
       ['25', 'master-card'],


### PR DESCRIPTION
closes #62 

Series 2 bins are in the range `222100-272099` (https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html), and our pattern doesn't account for all cards in those ranges.

Checked this against the pattern that Braintree uses on the server to validate Mastercards.