### PR TITLE
Add `Mir` card definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Named variables are provided for each of the supported card types:
 * `JCB`
 * `UNIONPAY`
 * `MAESTRO`
+* `MIR`
 
 #### `code`
 
@@ -80,6 +81,7 @@ Card brands provide different nomenclature for their security codes as well as v
 | `JCB`              | `CVV` | 3    |
 | `UnionPay`         | `CVN` | 3    |
 | `Maestro`          | `CVC` | 3    |
+| `Mir`              | `CVP` | 3    |
 
 A full response for a `Visa` card will look like this:
 
@@ -177,7 +179,8 @@ Adding new cards puts them at the bottom of the priority for testing. Priority i
   creditCardType.types.DISCOVER,
   creditCardType.types.JCB,
   creditCardType.types.UNIONPAY,
-  creditCardType.types.MAESTRO
+  creditCardType.types.MAESTRO,
+  creditCardType.types.MIR
 ]
 ```
 

--- a/index.js
+++ b/index.js
@@ -11,10 +11,12 @@ var DISCOVER = 'discover';
 var JCB = 'jcb';
 var UNIONPAY = 'unionpay';
 var MAESTRO = 'maestro';
+var MIR = 'mir';
 var CVV = 'CVV';
 var CID = 'CID';
 var CVC = 'CVC';
 var CVN = 'CVN';
+var CVP2 = 'CVP2';
 var ORIGINAL_TEST_ORDER = [
   VISA,
   MASTERCARD,
@@ -23,7 +25,8 @@ var ORIGINAL_TEST_ORDER = [
   DISCOVER,
   JCB,
   UNIONPAY,
-  MAESTRO
+  MAESTRO,
+  MIR
 ];
 
 function clone(originalObject) {
@@ -141,6 +144,19 @@ types[MAESTRO] = {
   lengths: [12, 13, 14, 15, 16, 17, 18, 19],
   code: {
     name: CVC,
+    size: 3
+  }
+};
+
+types[MIR] = {
+  niceType: 'Mir',
+  type: MIR,
+  prefixPattern: /^(2|22|220|220[0-4])$/,
+  exactPattern: /^(220[0-4])\d*$/,
+  gaps: [4, 8, 12],
+  lengths: [16, 17, 18, 19],
+  code: {
+    name: CVP2,
     size: 3
   }
 };

--- a/index.js
+++ b/index.js
@@ -243,7 +243,8 @@ creditCardType.types = {
   DISCOVER: DISCOVER,
   JCB: JCB,
   UNIONPAY: UNIONPAY,
-  MAESTRO: MAESTRO
+  MAESTRO: MAESTRO,
+  MIR: MIR
 };
 
 module.exports = creditCardType;

--- a/test/index.js
+++ b/test/index.js
@@ -126,7 +126,12 @@ describe('creditCardType', function () {
       ['6221558812340000', 'unionpay'],
       ['6269992058134322', 'unionpay'],
       ['622018111111111111', 'unionpay'],
-      ['6220181111111111111', 'maestro']
+      ['6220181111111111111', 'maestro'],
+
+      ['2200', 'mir'],
+      ['2204', 'mir'],
+      ['22000000000000000', 'mir'],
+      ['22049999999999999', 'mir']
     ];
 
     tests.forEach(function (test) {
@@ -144,8 +149,8 @@ describe('creditCardType', function () {
 
   describe('ambiguous card types', function () {
     var ambiguous = [
-      ['', ['visa', 'master-card', 'american-express', 'diners-club', 'discover', 'jcb', 'unionpay', 'maestro']],
-      ['2', ['master-card', 'jcb']],
+      ['', ['visa', 'master-card', 'american-express', 'diners-club', 'discover', 'jcb', 'unionpay', 'maestro', 'mir']],
+      ['2', ['master-card', 'jcb', 'mir']],
       ['3', ['american-express', 'diners-club', 'jcb']],
       ['5', ['master-card', 'maestro']],
       ['6', ['discover', 'maestro', 'unionpay']],
@@ -254,6 +259,13 @@ describe('creditCardType', function () {
       expect(code.size).to.equal(3);
       expect(code.name).to.equal('CVC');
     });
+
+    it('Mir', function () {
+      var code = creditCardType('2200000000000000')[0].code;
+
+      expect(code.size).to.equal(3);
+      expect(code.name).to.equal('CVP2');
+    });
   });
 
   describe('returns lengths for', function () {
@@ -273,6 +285,9 @@ describe('creditCardType', function () {
       expect(creditCardType('54')[0].lengths).to.deep.equal([16]);
     });
     it('JCB', function () {
+      expect(creditCardType('35')[0].lengths).to.deep.equal([16, 17, 18, 19]);
+    });
+    it('Mir', function () {
       expect(creditCardType('35')[0].lengths).to.deep.equal([16, 17, 18, 19]);
     });
   });
@@ -391,16 +406,18 @@ describe('removeCard', function () {
   it('removes card from test order array', function () {
     var result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(2);
+    expect(result).to.have.a.lengthOf(3);
     expect(result[0].type).to.equal('master-card');
     expect(result[1].type).to.equal('jcb');
+    expect(result[2].type).to.equal('mir');
 
     creditCardType.removeCard('master-card');
 
     result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(1);
+    expect(result).to.have.a.lengthOf(2);
     expect(result[0].type).to.equal('jcb');
+    expect(result[1].type).to.equal('mir');
   });
 
   it('throws an error if card type is passed which is not in the array', function () {
@@ -418,9 +435,10 @@ describe('addCard', function () {
   it('adds new card type', function () {
     var result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(2);
+    expect(result).to.have.a.lengthOf(3);
     expect(result[0].type).to.equal('master-card');
     expect(result[1].type).to.equal('jcb');
+    expect(result[2].type).to.equal('mir');
 
     creditCardType.addCard({
       niceType: 'NewCard',
@@ -437,10 +455,11 @@ describe('addCard', function () {
 
     result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(3);
+    expect(result).to.have.a.lengthOf(4);
     expect(result[0].type).to.equal('master-card');
     expect(result[1].type).to.equal('jcb');
-    expect(result[2].type).to.equal('new-card');
+    expect(result[2].type).to.equal('mir');
+    expect(result[3].type).to.equal('new-card');
   });
 
   it('can overwrite existing cards', function () {
@@ -477,7 +496,7 @@ describe('addCard', function () {
   it('adds new card to last position in card list', function () {
     var result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(2);
+    expect(result).to.have.a.lengthOf(3);
 
     creditCardType.addCard({
       niceType: 'NewCard',
@@ -494,8 +513,8 @@ describe('addCard', function () {
 
     result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(3);
-    expect(result[2].type).to.equal('new-card');
+    expect(result).to.have.a.lengthOf(4);
+    expect(result[3].type).to.equal('new-card');
 
     creditCardType.addCard({
       niceType: 'NewCard 2',
@@ -512,9 +531,9 @@ describe('addCard', function () {
 
     result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(4);
-    expect(result[2].type).to.equal('new-card');
-    expect(result[3].type).to.equal('another-new-card');
+    expect(result).to.have.a.lengthOf(5);
+    expect(result[3].type).to.equal('new-card');
+    expect(result[4].type).to.equal('another-new-card');
   });
 });
 
@@ -526,17 +545,19 @@ describe('changeOrder', function () {
   it('changes test order priority', function () {
     var result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(2);
+    expect(result).to.have.a.lengthOf(3);
     expect(result[0].type).to.equal('master-card');
     expect(result[1].type).to.equal('jcb');
+    expect(result[2].type).to.equal('mir');
 
     creditCardType.changeOrder('jcb', 0);
 
     result = creditCardType('2');
 
-    expect(result).to.have.a.lengthOf(2);
+    expect(result).to.have.a.lengthOf(3);
     expect(result[0].type).to.equal('jcb');
     expect(result[1].type).to.equal('master-card');
+    expect(result[2].type).to.equal('mir');
   });
 
   it('throws an error if card type is passed which is not in the array', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -566,3 +566,12 @@ describe('changeOrder', function () {
     }).to.throw('"bogus" is not a supported card type.');
   });
 });
+
+describe('types', function () {
+  it('correspond to internals', function () {
+    var exposedTypes = Object.keys(creditCardType.types).map(function (key) { return creditCardType.types[key]; });
+    var internalTypes = creditCardType('').map(function (entry) { return entry.type; });
+
+    expect(exposedTypes).to.deep.equal(internalTypes);
+  });
+});


### PR DESCRIPTION
Introduce definitions for `Mir` payment system. This impl is in strict accordance with the official documentation: [mironline.ru](http://mironline.ru/), [nspk.ru](http://www.nspk.ru/)

Reasonable notes:
* PAN belongs to range [22000..., 22049...]
* Permissible PAN lengths: 16, 17, 18, 19
* `CVP` means `Card verification parameter` aka `Проверочный параметр карты`. 