### PR TITLE
Correcting the issue 107 ELO/Maestro incorrect type

### DIFF
--- a/src/lib/card-types.ts
+++ b/src/lib/card-types.ts
@@ -107,7 +107,16 @@ const cardTypes: CardCollection = {
   maestro: {
     niceType: "Maestro",
     type: "maestro",
-    patterns: [493698, [500000, 506698], [506779, 508999], [56, 59], 63, 67, 6],
+    patterns: [
+      493698,
+      [500000, 504174],
+      [504176, 506698],
+      [506779, 508999],
+      [56, 59],
+      63,
+      67,
+      6,
+    ],
     gaps: [4, 8, 12],
     lengths: [12, 13, 14, 15, 16, 17, 18, 19],
     code: {


### PR DESCRIPTION
Hi!

I opened  the issue 107:
https://github.com/braintree/credit-card-type/issues/107

After the typerscript migration I'm opening a pull request to correct the problem using the @crookedneighbor  proposal.

## How to test:
```JS
const eloCard = creditCardType('504175');
console.log(eloCard);
```

Expected result:
```JS
[ { niceType: 'Elo',
    type: 'elo',
    patterns:
     [ 401178,
(...)
    gaps: [ 4, 8, 12 ],
    lengths: [ 16 ],
    code: { name: 'CVE', size: 3 },
    matchStrength: 6 } ]

```