### PR TITLE
adding missing HIPER bins

### DIFF
--- a/src/lib/card-types.ts
+++ b/src/lib/card-types.ts
@@ -175,7 +175,7 @@ const cardTypes: CardCollection = {
   hiper: {
     niceType: "Hiper",
     type: "hiper",
-    patterns: [637095, 637568, 637599, 637609, 637612],
+    patterns: [637095, 637568, 637599, 637609, 637612, 63743358, 63737423],
     gaps: [4, 8, 12],
     lengths: [16],
     code: {


### PR DESCRIPTION
we have discovered that HIPER Bins are missing in this library during BR migration. in this pr, i am trying to add the missing bins fro BR as per the paypal internal documentation.