### PR TITLE
Fix incorrect typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ type CreditCardTypeSecurityCodeLabel =
 export type CreditCardType = {
   niceType: string;
   type: string;
-  patterns: number[] | [number[]];
+  patterns: number[] | number[][];
   gaps: number[];
   lengths: number[];
   code: {


### PR DESCRIPTION
The [README](https://github.com/braintree/credit-card-type#adding-card-types) shows an `addCard` example  that uses a pattern not currently valid with the `CreditCardType.patterns` type. 

`[number[]]` should be `number[][]`

This accurately represents credit-card-type's pattern functionality and allows the README example to work:

```typescript
creditCardType.addCard({
  niceType: "Visa with Custom Nice Type",
  type: creditCardType.types.VISA,
  patterns: [41111, [44, 47]],
  gaps: [4, 8, 12],
  lengths: [13, 16, 19], // add support for old, deprecated 13 digit visas
  code: {
    name: "CVV",
    size: 3,
  },
});
```